### PR TITLE
patch for issue 1481. please pull the changeset.

### DIFF
--- a/djblets/util/fields.py
+++ b/djblets/util/fields.py
@@ -149,8 +149,8 @@ class JSONField(models.TextField):
                                   **kwargs)
         self.encoder = encoder
 
-    def db_type(self, connection=None):
-        return "text"
+    def get_internal_type(self):
+        return "TextField"
 
     def contribute_to_class(self, cls, name):
         def get_json(model_instance):


### PR DESCRIPTION
Now, JSONField uses same data type as TextField.
This change is compatible with Django 1.1 and 1.2.

Fixes bug 1481.
