### PR TITLE
Fixes potential XSS at any page containing grid.

### DIFF
--- a/djblets/datagrid/grids.py
+++ b/djblets/datagrid/grids.py
@@ -26,6 +26,7 @@
 
 import logging
 import pytz
+import urllib
 
 from django.conf import settings
 from django.contrib.auth.models import SiteProfileNotAvailable
@@ -200,13 +201,12 @@ class Column(object):
         Utility function to return a string containing URL parameters to
         this page with the specified parameter filtered out.
         """
-        s = ""
-
-        for key in self.datagrid.request.GET:
-            if key not in params:
-                s += "%s=%s&" % (key, self.datagrid.request.GET[key])
-
-        return s
+        result = urllib.urlencode([
+            (key, value)
+            for key, value in self.datagrid.request.GET.items()
+            if key not in params
+        ])
+        return result + '&'
 
     def collect_objects(self, object_list):
         """Iterates through the objects and builds a cache of data to display.


### PR DESCRIPTION
Every site, containing datagrids, can be hacked,
using simple XSS, leading to cookies leak.

To reproduce the problem, go to any site, wich uses
djblets.datagrid. For example, open: <a href="http://demo.reviewboard.org/r/?111'%3balert(document.cookie)//222=1">Demo ReviewBoard</a>

Note, that  ?111'%3balert(document.cookie)//222=1 was added to the end of the URL. That is the way, how a cookie thief will prepare the URL for his victim.

Then click to any table's header and you'll see an alert box with all
your cookies.
