### PR TITLE
Allow 'some.other.object.field' specification.

### DIFF
--- a/djblets/datagrid/grids.py
+++ b/djblets/datagrid/grids.py
@@ -302,12 +302,15 @@ class Column(object):
                 self.data_cache[pk] = value
                 return value
         else:
-            value = getattr(obj, self.field_name)
+            # allow to use 'some.other.object.field' specification
+            value = obj
+            for field_name in filter(None, self.field_name.split('.')):
+                value = getattr(value, field_name)
 
-            if callable(value):
-                return value()
-            else:
-                return value
+                if callable(value):
+                    value = value()
+
+            return value
 
     def augment_queryset(self, queryset):
         """Augments a queryset with new queries.


### PR DESCRIPTION
It is useful, if you want to output value of some child object's field in the column, like that:

``` python
full_name = Column(_(u'Full Name'), field_name='user.get_fullname')
```
