### PR TITLE
Fixed get_url_params_except function to work with not ascii contain quer...

### DIFF
--- a/djblets/util/http.py
+++ b/djblets/util/http.py
@@ -205,8 +205,9 @@ def get_url_params_except(query, *params):
     This is used often when one wants to preserve some GET parameters and not
     others.
     """
+
     return urlencode([
-        (key, value)
+        (key, value.encode('utf-8'))
         for key, value in six.iteritems(query)
         if key not in params
     ])


### PR DESCRIPTION
There are an error in urlencode if query contains non ascii strings.
