### PR TITLE
Avoid deleting previous PYTHONPATH

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ class BuildI18n(Command):
         # location (such as distribution packaging), we need to
         # ensure that the source directory is in the PYTHONPATH
         # or the import of djblets.util.filesystem will fail.
-        os.putenv("PYTHONPATH", "%s" % os.getcwd())
+        sys.path.append ("%s" % os.getcwd())
         retcode = subprocess.call([
             sys.executable, 'contrib/internal/build-i18n.py'])
 


### PR DESCRIPTION
With the previous putenv command, if an user had already set the PYTHONPATH environment variable, its value was deleted and substituted by os.getcwd(), which may prevent the installation if the dependencies are installed in a different path. Now, it appends this value to the previous value set in the sys.path, so the user configuration is kept.
