### PR TITLE
Fix UnicodeDecodeError when log contains an Umlaut (Ö,Ü,Ä)

### DIFF
--- a/djblets/log/views.py
+++ b/djblets/log/views.py
@@ -31,6 +31,7 @@ import logging
 import os
 import re
 import time
+import codecs
 
 from django.conf import settings
 from django.contrib.admin.views.decorators import staff_member_required
@@ -106,7 +107,7 @@ def iter_log_lines(from_timestamp, to_timestamp, requested_levels):
     line_info = None
 
     try:
-        fp = open(log_filename, 'r')
+        fp = codecs.open(log_filename, encoding='utf-8')
     except IOError:
         # We'd log this, but it'd do very little good in practice.
         # It would only appear on the console when using the development


### PR DESCRIPTION
When the log file to be opened contains Umlauts, like in my case: `error: [Errno 10013] Der Zugriff auf einen Socket war aufgrund der Zugriffsrechte des Sockets unzulässig`

An UnicodeDecodeError exception is thrown:

    File "C:\Python27\lib\site-packages\djblets-0.8.15-py2.7.egg\djblets\log\views.py", line 148, in iter_log_lines
       line_info[2] + "\n" + line)
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 99: ordinal not in range(128)

To fix this error I used the solution proposed in the doc: [https://docs.python.org/2/howto/unicode.html](https://docs.python.org/2/howto/unicode.html)

The change was validated on Python 2.7.9 x64 Win

Best regards, Stefan