### PR TITLE
add pillowfight

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(name=PACKAGE_NAME,
       install_requires=[
           'Django>=1.3.7,<1.4',
           'feedparser>=5.1.2',
-          'PIL'
+          'pillowfight'
       ],
       dependency_links = [
           "http://downloads.reviewboard.org/mirror/",


### PR DESCRIPTION
Reopening of closed djblets/djblets/#14 ...

I do not understand your point of view, @davidt , this wont use Pillow if you have PIL first.
But installation of some other softwares, says  seafile that still relies on 0.6.x, could be easier with that and totally broken without (thx...).

Maybe, elseway, the other option is to REMOVE ANY PIL DEPENDENCY to let the user decides it's Image implementation when using djblets.